### PR TITLE
Tweak installation/clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ Installing should be as simple as cloning this repository to your LaunchBar
 Actions folder:
 
 ```
-git clone https://github.com/bswinnerton/GitHub.lbaction ~/Library/Application\ Support/LaunchBar/Actions
+git clone https://github.com/bswinnerton/GitHub.lbaction ~/Library/Application\ Support/LaunchBar/Actions/GitHub.lbaction
 ```

--- a/README.md
+++ b/README.md
@@ -32,5 +32,6 @@ Installing should be as simple as cloning this repository to your LaunchBar
 Actions folder:
 
 ```
+mkdir -p ~/Library/Application\ Support/LaunchBar/Actions/
 git clone https://github.com/bswinnerton/GitHub.lbaction ~/Library/Application\ Support/LaunchBar/Actions/GitHub.lbaction
 ```


### PR DESCRIPTION
Prior to this change, I get the following error when following the installation instructions:

```
$ git clone https://github.com/bswinnerton/GitHub.lbaction ~/Library/Application\ Support/LaunchBar/Actions
fatal: destination path '~/Library/Application Support/LaunchBar/Actions' already exists and is not an empty directory.
```

After this change:

```
$ git clone https://github.com/bswinnerton/GitHub.lbaction ~/Library/Application\ Support/LaunchBar/Actions/GitHub.lbaction
Cloning into '~/Library/Application Support/LaunchBar/Actions/GitHub.lbaction'...
remote: Counting objects: 263, done.
remote: Total 263 (delta 0), reused 0 (delta 0), pack-reused 263
Receiving objects: 100% (263/263), 716.25 KiB | 0 bytes/s, done.
Resolving deltas: 100% (98/98), done.
```

